### PR TITLE
[fix] TLS client config not obeying root CA pool supplied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **[FIX]** Generated certificates now include the issuer CA certificate in the chain (thanks [@koshatul])
 - **[NEW]** Add support for parsing the client's remote address from [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) headers (thanks [@koshatul])
 - **[NEW]** Add `CA_PATH` environment variable for specifying the location of CA bundles
+- **[FIX]** `CA_PATH` did not affect connections to upstream services ([@koshatul])
 
 ## 0.3.3 (2017-03-16)
 

--- a/src/cmd/honeycomb/main.go
+++ b/src/cmd/honeycomb/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"time"
 
 	"github.com/docker/docker/client"
 	"github.com/icecave/honeycomb/src/backend"
@@ -83,9 +84,20 @@ func main() {
 		RootCAs:        rootCACertPool,
 	}
 
-	httpProxyTransport := http.DefaultTransport
-	httpProxyTransport.(*http.Transport).TLSClientConfig = &tls.Config{
-		RootCAs: rootCACertPool,
+	httpProxyTransport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig: &tls.Config{
+			RootCAs: rootCACertPool,
+		},
 	}
 
 	prepareTLSConfig(tlsConfig)

--- a/src/cmd/honeycomb/main.go
+++ b/src/cmd/honeycomb/main.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"time"
 
 	"github.com/docker/docker/client"
 	"github.com/icecave/honeycomb/src/backend"
@@ -85,16 +84,12 @@ func main() {
 	}
 
 	httpProxyTransport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-			DualStack: true,
-		}).DialContext,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
+		Proxy:                 http.DefaultTransport.(*http.Transport).Proxy,
+		DialContext:           http.DefaultTransport.(*http.Transport).DialContext,
+		MaxIdleConns:          http.DefaultTransport.(*http.Transport).MaxIdleConns,
+		IdleConnTimeout:       http.DefaultTransport.(*http.Transport).IdleConnTimeout,
+		TLSHandshakeTimeout:   http.DefaultTransport.(*http.Transport).TLSHandshakeTimeout,
+		ExpectContinueTimeout: http.DefaultTransport.(*http.Transport).ExpectContinueTimeout,
 		TLSClientConfig: &tls.Config{
 			RootCAs: rootCACertPool,
 		},


### PR DESCRIPTION
Fixes issue where specifying a custom `CA_PATH` would only affect the proxy listener, not the connection to the upstream server.