### PR TITLE
Change the `honeycomb.tls` label to accept a new "insecure" value.

### DIFF
--- a/src/backend/endpoint.go
+++ b/src/backend/endpoint.go
@@ -10,8 +10,22 @@ type Endpoint struct {
 	// port number or name.
 	Address string
 
-	// IsTLS indicates whether or not the back-end server is expecting a TLS
-	// connection. If true, the "https://" or "wss://" scheme is used; otherwise,
-	// "http://" or "ws://" is used.
-	IsTLS bool
+	// TLSMode indicates whether or not the back-end server is expecting a TLS
+	// connection.
+	TLSMode TLSMode
 }
+
+// TLSMode is an enumerationo of the TLS "modes" used by an endpoint.
+type TLSMode int
+
+const (
+	// TLSDisabled indicates that the endpoint does not use TLS.
+	TLSDisabled TLSMode = iota
+
+	// TLSEnabled indicates that the endpoint does use TLS.
+	TLSEnabled
+
+	// TLSInsecure indicates that the endpoint does use TLS, but that its
+	// certificate details should not be verified.
+	TLSInsecure
+)

--- a/src/docker/labels.go
+++ b/src/docker/labels.go
@@ -3,6 +3,6 @@ package docker
 const (
 	matchLabel       = "honeycomb.match"
 	portLabel        = "honeycomb.port"
-	isTLSLabel       = "honeycomb.tls"
+	tlsLabel         = "honeycomb.tls"
 	descriptionLabel = "honeycomb.description"
 )

--- a/src/proxy/http_proxy.go
+++ b/src/proxy/http_proxy.go
@@ -18,12 +18,7 @@ func (proxy *HTTPProxy) Forward(
 	upstreamRequest *http.Request,
 	logContext *LogContext,
 ) error {
-	transport := proxy.Transport
-	if transport == nil {
-		transport = http.DefaultTransport
-	}
-
-	upstreamResponse, err := transport.RoundTrip(upstreamRequest)
+	upstreamResponse, err := proxy.Transport.RoundTrip(upstreamRequest)
 	if err != nil {
 		return statuspage.Error{Inner: err, StatusCode: http.StatusBadGateway}
 	}

--- a/src/proxy/websocket_dialer.go
+++ b/src/proxy/websocket_dialer.go
@@ -7,24 +7,20 @@ import (
 	"strings"
 )
 
-// DefaultWebSocketDialer is the default dialer to use for connecting to
-// upstream websocket servers.
-var DefaultWebSocketDialer = &webSocketDialer{}
-
 // WebSocketDialer connects to an upstream websocket server.
 type WebSocketDialer interface {
 	// Dial connects to the websocket server described by request.
 	Dial(*http.Request) (net.Conn, error)
 }
 
-// webSocketDialer is the default WebSocketDialer implementation.
-type webSocketDialer struct {
+// BasicWebSocketDialer is the default WebSocketDialer implementation.
+type BasicWebSocketDialer struct {
 	Dialer    *net.Dialer
 	TLSConfig *tls.Config
 }
 
 // Dial connects to the websocket server described by request.
-func (dialer *webSocketDialer) Dial(
+func (dialer *BasicWebSocketDialer) Dial(
 	request *http.Request,
 ) (net.Conn, error) {
 	actual := dialer.Dialer

--- a/src/proxy/websocket_proxy.go
+++ b/src/proxy/websocket_proxy.go
@@ -27,11 +27,7 @@ func (proxy *WebSocketProxy) Forward(
 	}
 
 	// Connect to the upstream server ...
-	dialer := proxy.Dialer
-	if dialer == nil {
-		dialer = DefaultWebSocketDialer
-	}
-	upstreamConnection, err := dialer.Dial(upstreamRequest)
+	upstreamConnection, err := proxy.Dialer.Dial(upstreamRequest)
 	if err != nil {
 		return statuspage.Error{Inner: err, StatusCode: http.StatusBadGateway}
 	}

--- a/src/static/env.go
+++ b/src/static/env.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/icecave/honeycomb/src/backend"
 	"github.com/icecave/honeycomb/src/name"
@@ -48,20 +49,23 @@ func fromEnv(env []string) (Locator, error) {
 			return nil, err
 		}
 
-		isTLS := u.Scheme == "https" || u.Scheme == "wss"
+		tlsMode := backend.TLSDisabled
+		if strings.EqualFold(u.Scheme, "https") || strings.EqualFold(u.Scheme, "wss") {
+			tlsMode = backend.TLSEnabled
+		}
 
 		if port := u.Port(); port == "" {
-			if isTLS {
-				u.Host += ":443"
-			} else {
+			if tlsMode == backend.TLSDisabled {
 				u.Host += ":80"
+			} else {
+				u.Host += ":443"
 			}
 		}
 
 		endpoint := &backend.Endpoint{
 			Description: groups[tagIndex],
 			Address:     u.Host,
-			IsTLS:       isTLS,
+			TLSMode:     tlsMode,
 		}
 
 		if groups[descriptionIndex] != "" {

--- a/src/static/env_test.go
+++ b/src/static/env_test.go
@@ -24,47 +24,47 @@ var _ = Describe("FromEnv", func() {
 			Entry("TLS (https)", "ROUTE_FOO=foo.* https://foo.backend.com:1234", &backend.Endpoint{
 				Description: "FOO",
 				Address:     "foo.backend.com:1234",
-				IsTLS:       true,
+				TLSMode:     backend.TLSEnabled,
 			}),
 			Entry("non-TLS (http)", "ROUTE_FOO=foo.* http://foo.backend.com:1234", &backend.Endpoint{
 				Description: "FOO",
 				Address:     "foo.backend.com:1234",
-				IsTLS:       false,
+				TLSMode:     backend.TLSDisabled,
 			}),
 			Entry("TLS (wss)", "ROUTE_FOO=foo.* wss://foo.backend.com:1234", &backend.Endpoint{
 				Description: "FOO",
 				Address:     "foo.backend.com:1234",
-				IsTLS:       true,
+				TLSMode:     backend.TLSEnabled,
 			}),
 			Entry("non-TLS (ws)", "ROUTE_FOO=foo.* ws://foo.backend.com:1234", &backend.Endpoint{
 				Description: "FOO",
 				Address:     "foo.backend.com:1234",
-				IsTLS:       false,
+				TLSMode:     backend.TLSDisabled,
 			}),
 			Entry("TLS (https, implicit port)", "ROUTE_FOO=foo.* https://foo.backend.com", &backend.Endpoint{
 				Description: "FOO",
 				Address:     "foo.backend.com:443",
-				IsTLS:       true,
+				TLSMode:     backend.TLSEnabled,
 			}),
 			Entry("non-TLS (http, implicit port)", "ROUTE_FOO=foo.* http://foo.backend.com", &backend.Endpoint{
 				Description: "FOO",
 				Address:     "foo.backend.com:80",
-				IsTLS:       false,
+				TLSMode:     backend.TLSDisabled,
 			}),
 			Entry("TLS (wss, implicit port)", "ROUTE_FOO=foo.* wss://foo.backend.com", &backend.Endpoint{
 				Description: "FOO",
 				Address:     "foo.backend.com:443",
-				IsTLS:       true,
+				TLSMode:     backend.TLSEnabled,
 			}),
 			Entry("non-TLS (ws, implicit port)", "ROUTE_FOO=foo.* ws://foo.backend.com", &backend.Endpoint{
 				Description: "FOO",
 				Address:     "foo.backend.com:80",
-				IsTLS:       false,
+				TLSMode:     backend.TLSDisabled,
 			}),
 			Entry("custom description", "ROUTE_FOO=foo.* https://foo.backend.com:1234 This is the description!", &backend.Endpoint{
 				Description: "This is the description!",
 				Address:     "foo.backend.com:1234",
-				IsTLS:       true,
+				TLSMode:     backend.TLSEnabled,
 			}),
 		)
 


### PR DESCRIPTION
This indicates that upstream certificates should not be verified.

This necessitated selecting from a different proxy implementation for each request, as there's no way to set the "insecure-skip-verify" flag on a per-http request basic - it's bound to the transport's TLS config.