### PR TITLE
Increase healthcheck timeout from 500ms to 1500ms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM scratch
 
-HEALTHCHECK --interval=15s --timeout=500ms CMD ["/app/bin/healthcheck"]
+HEALTHCHECK --interval=15s --timeout=1500ms CMD ["/app/bin/healthcheck"]
 ENTRYPOINT ["/app/bin/honeycomb"]
 
 EXPOSE 8443

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -14,7 +14,7 @@ type Config struct {
 	DockerPollInterval time.Duration
 	Certificates       certificateConfig
 	ProxyProtocol      bool
-	CheckerTimeout     time.Duration
+	CheckTimeout       time.Duration
 }
 
 type certificateConfig struct {
@@ -43,8 +43,8 @@ func GetConfigFromEnvironment() *Config {
 				",",
 			),
 		},
-		ProxyProtocol:  envBool("PROXY_PROTOCOL", false),
-		CheckerTimeout: envDuration("CHECK_TIMEOUT", 500*time.Millisecond),
+		ProxyProtocol: envBool("PROXY_PROTOCOL", false),
+		CheckTimeout:  envDuration("CHECK_TIMEOUT", 500*time.Millisecond),
 	}
 }
 

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	DockerPollInterval time.Duration
 	Certificates       certificateConfig
 	ProxyProtocol      bool
+	CheckerTimeout     time.Duration
 }
 
 type certificateConfig struct {
@@ -42,7 +43,8 @@ func GetConfigFromEnvironment() *Config {
 				",",
 			),
 		},
-		ProxyProtocol: envBool("PROXY_PROTOCOL", false),
+		ProxyProtocol:  envBool("PROXY_PROTOCOL", false),
+		CheckerTimeout: envDuration("CHECK_TIMEOUT", 500*time.Millisecond),
 	}
 }
 
@@ -67,6 +69,18 @@ func envBool(key string, def bool) bool {
 	if value, ok := os.LookupEnv(key); ok {
 		i, _ := strconv.ParseBool(value)
 		return i
+	}
+
+	return def
+}
+
+func envDuration(key string, def time.Duration) time.Duration {
+	if value, ok := os.LookupEnv(key); ok {
+		d, err := time.ParseDuration(value)
+		if err != nil {
+			return def
+		}
+		return d
 	}
 
 	return def

--- a/src/cmd/healthcheck/main.go
+++ b/src/cmd/healthcheck/main.go
@@ -54,5 +54,6 @@ func checkerHTTPClientProvider(config *cmd.Config) *http.Client {
 	}
 	return &http.Client{
 		Transport: transport,
+		Timeout:   config.CheckerTimeout,
 	}
 }

--- a/src/cmd/healthcheck/main.go
+++ b/src/cmd/healthcheck/main.go
@@ -54,6 +54,6 @@ func checkerHTTPClientProvider(config *cmd.Config) *http.Client {
 	}
 	return &http.Client{
 		Transport: transport,
-		Timeout:   config.CheckerTimeout,
+		Timeout:   config.CheckTimeout,
 	}
 }

--- a/src/docker/health/http_checker_test.go
+++ b/src/docker/health/http_checker_test.go
@@ -51,14 +51,6 @@ var _ = Describe("HTTPChecker", func() {
 
 		subject = &health.HTTPChecker{
 			Address: serverURL.Host,
-			Client: &http.Client{
-				Timeout: 500 * time.Millisecond,
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{
-						InsecureSkipVerify: true,
-					},
-				},
-			},
 		}
 
 		slowSubject = &health.HTTPChecker{


### PR DESCRIPTION
#### What change does this introduce?

Increasing the timeout from 500ms to 1500ms because the `docker exec` takes much longer since `18.06`/`18.09`.

#### Why make this change?

Although it's a problem with the docker engine that may get addressed, until it is, it's better to have a longer timeout than having to disable healthchecks.

The extra time the exec takes is pushing the healthcheck over 500ms.

```
$ time docker exec proxy.1.j58fn826y197utu0uld4z7pd2 /app/bin/healthcheck
The server is connected to a Docker swarm manager.

real	0m0.769s
user	0m0.043s
sys	0m0.042s
```

```
$ docker exec proxy.1.j58fn826y197utu0uld4z7pd2 /bin/sh -c 'time /app/bin/healthcheck'
The server is connected to a Docker swarm manager.
real	0m 0.05s
user	0m 0.02s
sys	0m 0.00s
```

#### What approach will be taken?

Modified `Dockerfile`.
