### PR TITLE
replace User-Agent with 'Honeycomb/version' on the docker client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ APP_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 -include artifacts/make/go/Makefile
 -include artifacts/make/docker/Makefile
 
-DEBUG_ARGS = --ldflags "-X main.version=$(APP_VERSION)-debug"
+DEBUG_ARGS = -v --ldflags "-X main.version=$(APP_VERSION)-debug"
 RELEASE_ARGS = -v -ldflags "-X main.version=$(APP_VERSION) -s -w" -tags release
 
 .PHONY: docker-services

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,16 @@ DOCKER_TAG  ?= dev
 REQ += $(patsubst res/assets/%,artifacts/assets/%.go, $(wildcard res/assets/*))
 DOCKER_REQ += artifacts/cacert.pem
 
+GIT_HASH ?= $(shell git show -s --format=%h)
+GIT_TAG ?= $(shell git tag -l --merged $(GIT_HASH) | tail -n1)
+APP_VERSION ?= $(if $(TRAVIS_TAG),$(TRAVIS_TAG),$(if $(GIT_TAG),$(GIT_TAG),$(GIT_HASH)))
+APP_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
 -include artifacts/make/go/Makefile
 -include artifacts/make/docker/Makefile
+
+DEBUG_ARGS = --ldflags "-X main.version=$(APP_VERSION)-debug"
+RELEASE_ARGS = -v -ldflags "-X main.version=$(APP_VERSION) -s -w" -tags release
 
 .PHONY: docker-services
 docker-services: docker

--- a/glide.lock
+++ b/glide.lock
@@ -1,13 +1,18 @@
-hash: 9dcfc7e0e9fc6cbca7f14239952a4a2edabac4cd6fd7c9dcd8f9d1901b4c85de
-updated: 2019-03-28T14:38:32.987403+10:00
+hash: 19aa7a497002e4e1a276bd3029af29255a09fb8917369a8121cc75a81ca7fcfc
+updated: 2019-08-12T13:47:28.490696+10:00
 imports:
+- name: github.com/containerd/containerd
+  version: ea13c9fe9941b0714630aa614ef5a0038c0083a3
+  subpackages:
+  - errdefs
 - name: github.com/docker/distribution
-  version: 6d62eb1d4a3515399431b713fde3ce5a9b40e8d5
+  version: 7484e51bf6af0d3b1a849644cdaced3cfcf13617
   subpackages:
   - digestset
   - reference
+  - registry/api/errcode
 - name: github.com/docker/docker
-  version: 8422e6f6fa04eb8ee805a98067ee490a86ce3b98
+  version: 90af4ba5e7fa5a75387a06f8987c30217f05d618
   subpackages:
   - api
   - api/types
@@ -46,10 +51,21 @@ imports:
   subpackages:
   - httputil
   - httputil/header
+- name: github.com/golang/protobuf
+  version: 130e6b02ab059e7b717a096f397c5b60111cae74
+  subpackages:
+  - proto
+  - protoc-gen-go/descriptor
+  - ptypes
+  - ptypes/any
+  - ptypes/duration
+  - ptypes/empty
+  - ptypes/struct
+  - ptypes/timestamp
 - name: github.com/Microsoft/go-winio
   version: 4de24ed3e8c509e6d1f609a8cb6b1c9fd9816e6d
 - name: github.com/onsi/ginkgo
-  version: 505cc352255139defb7371000668063d1161e331
+  version: 0ecbc58698389c4a38c1b07e092f686286a73013
   subpackages:
   - config
   - extensions/table
@@ -71,7 +87,7 @@ imports:
   - reporters/stenographer/support/go-isatty
   - types
 - name: github.com/onsi/gomega
-  version: e0d4387cf37d6cc3baeb80f61bd24a37e5dfae26
+  version: 2e3b965217103f3054061bd78cb31bca3e94a0da
   subpackages:
   - format
   - internal/assertion
@@ -85,7 +101,7 @@ imports:
   - matchers/support/goraph/util
   - types
 - name: github.com/opencontainers/go-digest
-  version: ac19fd6e7483ff933754af248d80be865e543d22
+  version: 279bed98673dd5bef374d3b6e4b09e2af76183bf
 - name: github.com/opencontainers/image-spec
   version: 243ea084a44451d27322fed02b682d99e2af3ba9
   subpackages:
@@ -95,6 +111,16 @@ imports:
   version: 4d51b51e3bfc23ac5f4384478ff64940f34a5d63
 - name: github.com/pkg/errors
   version: 27936f6d90f9c8e1145f11ed52ffffbfdb9e0af7
+- name: github.com/sirupsen/logrus
+  version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
+- name: go.uber.org/atomic
+  version: df976f2515e274675050de7b3f42545de80594fd
+- name: go.uber.org/multierr
+  version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
+- name: golang.org/x/crypto
+  version: b3c9a1d25cfbbbab0ff4780b71c4f54e6e92a0de
+  subpackages:
+  - ssh/terminal
 - name: golang.org/x/net
   version: b60f3a92103dfd93dfcb900ec77c6d0643510868
   subpackages:
@@ -129,6 +155,28 @@ imports:
   - transform
   - unicode/bidi
   - unicode/norm
+- name: google.golang.org/genproto
+  version: 1e559d0a00eef8a9a43151db4665280bd8dd5886
+  subpackages:
+  - googleapis/api/annotations
+  - googleapis/api/distribution
+  - googleapis/api/label
+  - googleapis/api/metric
+  - googleapis/api/monitoredres
+  - googleapis/iam/v1
+  - googleapis/logging/type
+  - googleapis/logging/v2
+  - googleapis/pubsub/v1
+  - googleapis/rpc/status
+  - protobuf/field_mask
+- name: google.golang.org/grpc
+  version: 045159ad57f3781d409358e3ade910a018c16b30
+  subpackages:
+  - codes
+  - connectivity
+  - grpclog
+  - internal
+  - status
 testImports:
 - name: github.com/hpcloud/tail
   version: a1dbeea552b7c8df4b542c66073e393de198a800

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,3 +19,12 @@ import:
   - httputil
 - package: github.com/dustin/go-humanize
 - package: github.com/pires/go-proxyproto
+- package: go.uber.org/multierr
+  version: ~1.1.0
+- package: go.uber.org/atomic
+  version: ~1.4.0
+- package: google.golang.org/grpc
+  version: ~1.22.1
+  subpackages:
+  - codes
+  - status


### PR DESCRIPTION
#### What change does this introduce?

Updated the docker client library and created a function to combine the recommended `client.FromEnv` function replacing now deprecated the `client. NewEnvClient`.

#### Why make this change?

To assist with reading logs and assigning requests against the docker daemon to Honeycomb, just log things.

#### What approach will be taken?

Replacing the 'User-Agent' which was the generic `Go-http-client/1.1` with `Honeycomb/0.3.6` (version compiled in when built using last tag in commit history).