### PR TITLE
Add match ranking to ensure longer patterns take precedence.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ sudo: required
 language: go
 go:
 - '1.12'
-- tip
-matrix:
-  fast_finish: true
-  allow_failures:
-  - go: tip
 services:
 - docker
 script: make ci

--- a/glide.lock
+++ b/glide.lock
@@ -1,18 +1,14 @@
-hash: 19aa7a497002e4e1a276bd3029af29255a09fb8917369a8121cc75a81ca7fcfc
-updated: 2019-08-12T13:47:28.490696+10:00
+hash: 6cd8808f5ddb15045dd200bd7a13092c7cde9ddf542321f817eb201656852f5e
+updated: 2019-08-29T10:33:42.329931+10:00
 imports:
-- name: github.com/containerd/containerd
-  version: ea13c9fe9941b0714630aa614ef5a0038c0083a3
-  subpackages:
-  - errdefs
 - name: github.com/docker/distribution
   version: 7484e51bf6af0d3b1a849644cdaced3cfcf13617
   subpackages:
   - digestset
   - reference
-  - registry/api/errcode
 - name: github.com/docker/docker
-  version: 90af4ba5e7fa5a75387a06f8987c30217f05d618
+  version: 456712c5b8d9d92c047f6a7d7cff270527ecac28
+  repo: git@github.com:docker/engine.git
   subpackages:
   - api
   - api/types
@@ -51,21 +47,10 @@ imports:
   subpackages:
   - httputil
   - httputil/header
-- name: github.com/golang/protobuf
-  version: 130e6b02ab059e7b717a096f397c5b60111cae74
-  subpackages:
-  - proto
-  - protoc-gen-go/descriptor
-  - ptypes
-  - ptypes/any
-  - ptypes/duration
-  - ptypes/empty
-  - ptypes/struct
-  - ptypes/timestamp
 - name: github.com/Microsoft/go-winio
   version: 4de24ed3e8c509e6d1f609a8cb6b1c9fd9816e6d
 - name: github.com/onsi/ginkgo
-  version: 0ecbc58698389c4a38c1b07e092f686286a73013
+  version: 66915d68818eb42dadcd44b3e2e3a3bf75da2a74
   subpackages:
   - config
   - extensions/table
@@ -87,7 +72,7 @@ imports:
   - reporters/stenographer/support/go-isatty
   - types
 - name: github.com/onsi/gomega
-  version: 2e3b965217103f3054061bd78cb31bca3e94a0da
+  version: bdebf9e0ece900259084cfa4121b97ce1a540939
   subpackages:
   - format
   - internal/assertion
@@ -111,19 +96,15 @@ imports:
   version: 4d51b51e3bfc23ac5f4384478ff64940f34a5d63
 - name: github.com/pkg/errors
   version: 27936f6d90f9c8e1145f11ed52ffffbfdb9e0af7
-- name: github.com/sirupsen/logrus
-  version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
 - name: go.uber.org/atomic
   version: df976f2515e274675050de7b3f42545de80594fd
 - name: go.uber.org/multierr
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
-- name: golang.org/x/crypto
-  version: b3c9a1d25cfbbbab0ff4780b71c4f54e6e92a0de
-  subpackages:
-  - ssh/terminal
 - name: golang.org/x/net
   version: b60f3a92103dfd93dfcb900ec77c6d0643510868
   subpackages:
+  - context
+  - context/ctxhttp
   - html
   - html/atom
   - html/charset
@@ -155,27 +136,10 @@ imports:
   - transform
   - unicode/bidi
   - unicode/norm
-- name: google.golang.org/genproto
-  version: 1e559d0a00eef8a9a43151db4665280bd8dd5886
-  subpackages:
-  - googleapis/api/annotations
-  - googleapis/api/distribution
-  - googleapis/api/label
-  - googleapis/api/metric
-  - googleapis/api/monitoredres
-  - googleapis/iam/v1
-  - googleapis/logging/type
-  - googleapis/logging/v2
-  - googleapis/pubsub/v1
-  - googleapis/rpc/status
-  - protobuf/field_mask
 - name: google.golang.org/grpc
-  version: 045159ad57f3781d409358e3ade910a018c16b30
+  version: 7150a7c70aef304650b166dfc30a1a2287cad773
   subpackages:
   - codes
-  - connectivity
-  - grpclog
-  - internal
   - status
 testImports:
 - name: github.com/hpcloud/tail

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 6cd8808f5ddb15045dd200bd7a13092c7cde9ddf542321f817eb201656852f5e
-updated: 2019-08-29T10:33:42.329931+10:00
+hash: 63cbcfc16a2200cfe1efe108d10e5abf4e93fc6e43e4a1d8aef1376e9ea31f27
+updated: 2019-08-29T10:43:31.247468+10:00
 imports:
 - name: github.com/docker/distribution
   version: 7484e51bf6af0d3b1a849644cdaced3cfcf13617
@@ -8,7 +8,7 @@ imports:
   - reference
 - name: github.com/docker/docker
   version: 456712c5b8d9d92c047f6a7d7cff270527ecac28
-  repo: git@github.com:docker/engine.git
+  repo: https://github.com/docker/engine.git
   subpackages:
   - api
   - api/types

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,8 @@
 package: github.com/icecave/honeycomb
 import:
 - package: github.com/docker/docker
-  version: master
+  version: ~18.09
+  repo: git@github.com:docker/engine.git
   subpackages:
   - api/types
   - client

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,7 +2,7 @@ package: github.com/icecave/honeycomb
 import:
 - package: github.com/docker/docker
   version: ~18.09
-  repo: git@github.com:docker/engine.git
+  repo: https://github.com/docker/engine.git
   subpackages:
   - api/types
   - client

--- a/src/backend/aggregate_locator.go
+++ b/src/backend/aggregate_locator.go
@@ -10,12 +10,22 @@ import (
 type AggregateLocator []Locator
 
 // Locate finds the back-end HTTP server for the given server name.
-func (locator AggregateLocator) Locate(ctx context.Context, serverName name.ServerName) *Endpoint {
+//
+// It returns a score indicating the strength of the match. A value of 0 or
+// less indicates that no match was made, in which case ep is nil.
+//
+// A non-zero score can be returned with a nil endpoint, indicating that the
+// request should not be routed.
+func (locator AggregateLocator) Locate(
+	ctx context.Context,
+	serverName name.ServerName,
+) (ep *Endpoint, score int) {
 	for _, loc := range locator {
-		if endpoint := loc.Locate(ctx, serverName); endpoint != nil {
-			return endpoint
+		if e, s := loc.Locate(ctx, serverName); s > score {
+			ep = e
+			score = s
 		}
 	}
 
-	return nil
+	return ep, score
 }

--- a/src/backend/cache.go
+++ b/src/backend/cache.go
@@ -1,0 +1,59 @@
+package backend
+
+import (
+	"context"
+	"sync"
+
+	"github.com/icecave/honeycomb/src/name"
+)
+
+// Cache is a Locator that caches the results of another locator.
+type Cache struct {
+	Next Locator
+
+	m     sync.RWMutex
+	cache map[name.ServerName]cacheEntry
+}
+
+type cacheEntry struct {
+	Endpoint *Endpoint
+	Score    int
+}
+
+// Clear clears the cache.
+func (c *Cache) Clear() {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	c.cache = nil
+}
+
+// Locate finds the back-end HTTP server for the given server name.
+//
+// It returns a score indicating the strength of the match. A value of 0 or
+// less indicates that no match was made, in which case ep is nil.
+//
+// A non-zero score can be returned with a nil endpoint, indicating that the
+// request should not be routed.
+func (c *Cache) Locate(ctx context.Context, serverName name.ServerName) (ep *Endpoint, score int) {
+	c.m.RLock()
+	e, ok := c.cache[serverName]
+	c.m.RUnlock()
+
+	if ok {
+		return e.Endpoint, e.Score
+	}
+
+	ep, score = c.Next.Locate(ctx, serverName)
+
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	if c.cache == nil {
+		c.cache = map[name.ServerName]cacheEntry{}
+	}
+
+	c.cache[serverName] = cacheEntry{ep, score}
+
+	return ep, score
+}

--- a/src/backend/cache.go
+++ b/src/backend/cache.go
@@ -20,14 +20,6 @@ type cacheEntry struct {
 	Score    int
 }
 
-// Clear clears the cache.
-func (c *Cache) Clear() {
-	c.m.Lock()
-	defer c.m.Unlock()
-
-	c.cache = nil
-}
-
 // Locate finds the back-end HTTP server for the given server name.
 //
 // It returns a score indicating the strength of the match. A value of 0 or
@@ -56,4 +48,12 @@ func (c *Cache) Locate(ctx context.Context, serverName name.ServerName) (ep *End
 	c.cache[serverName] = cacheEntry{ep, score}
 
 	return ep, score
+}
+
+// Clear clears the cache.
+func (c *Cache) Clear() {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	c.cache = nil
 }

--- a/src/backend/cache_test.go
+++ b/src/backend/cache_test.go
@@ -1,0 +1,87 @@
+package backend_test
+
+import (
+	"context"
+
+	"github.com/icecave/honeycomb/src/backend"
+	"github.com/icecave/honeycomb/src/name"
+	"github.com/icecave/honeycomb/src/static"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cache", func() {
+	var (
+		next    static.Locator
+		subject *backend.Cache
+	)
+
+	BeforeEach(func() {
+		next = static.Locator{}.
+			With("foo", &backend.Endpoint{Address: "static-foo:443"})
+
+		subject = &backend.Cache{
+			Next: next,
+		}
+	})
+
+	Describe("Locate", func() {
+		It("locates endpoints from the inner locator", func() {
+			endpoint, score := subject.Locate(
+				context.Background(),
+				name.Parse("foo"),
+			)
+			Expect(endpoint).ShouldNot(BeNil())
+			Expect(endpoint.Address).To(Equal("static-foo:443"))
+			Expect(score).To(BeNumerically(">", 0))
+		})
+
+		It("returns prior matches from the cache", func() {
+			// prime the cache
+			subject.Locate(
+				context.Background(),
+				name.Parse("foo"),
+			)
+
+			subject.Next = static.Locator{}
+
+			endpoint, score := subject.Locate(
+				context.Background(),
+				name.Parse("foo"),
+			)
+			Expect(endpoint).ShouldNot(BeNil())
+			Expect(endpoint.Address).To(Equal("static-foo:443"))
+			Expect(score).To(BeNumerically(">", 0))
+		})
+
+		It("returns nil and a non-positive score if none of the inner locators can locate the endpoint", func() {
+			endpoint, score := subject.Locate(
+				context.Background(),
+				name.Parse("unknown"),
+			)
+			Expect(endpoint).To(BeNil())
+			Expect(score).To(BeNumerically("<=", 0))
+		})
+	})
+
+	Describe("Clear", func() {
+		It("invalidates the cache", func() {
+			// prime the cache
+			subject.Locate(
+				context.Background(),
+				name.Parse("foo"),
+			)
+
+			subject.Next = static.Locator{}
+			subject.Clear()
+
+			endpoint, score := subject.Locate(
+				context.Background(),
+				name.Parse("foo"),
+			)
+			Expect(endpoint).Should(BeNil())
+			Expect(score).To(BeNumerically("<=", 0))
+		})
+	})
+
+})

--- a/src/backend/locator.go
+++ b/src/backend/locator.go
@@ -10,5 +10,11 @@ import (
 // requests (SNI).
 type Locator interface {
 	// Locate finds the back-end HTTP server for the given server name.
-	Locate(ctx context.Context, serverName name.ServerName) *Endpoint
+	//
+	// It returns a score indicating the strength of the match. A value of 0 or
+	// less indicates that no match was made, in which case ep is nil.
+	//
+	// A non-zero score can be returned with a nil endpoint, indicating that the
+	// request should not be routed.
+	Locate(ctx context.Context, serverName name.ServerName) (ep *Endpoint, score int)
 }

--- a/src/name/matcher.go
+++ b/src/name/matcher.go
@@ -81,10 +81,7 @@ func (matcher Matcher) Match(serverName ServerName) int {
 		}
 	} else {
 		if serverName.Unicode == matcher.fixedPart {
-			// an exact match always scores higher that a wildcard match that matches
-			// the same number of characters.
-			const max = int(^uint(0) >> 1)
-			return max
+			return score
 		}
 	}
 

--- a/src/name/matcher_test.go
+++ b/src/name/matcher_test.go
@@ -82,9 +82,6 @@ var _ = Describe("Matcher", func() {
 		It("scores wildcard matches appropriately", func() {
 			serverName := name.Parse("w.prefix.example.x")
 
-			// note: subject3 is an exact matcher for the server name, but as
-			// the same "fixedPart" length as the wildcard subject4, yet it must
-			// still score higher.
 			subject1, _ := name.NewMatcher("*")
 			subject2, _ := name.NewMatcher("*.example.*")
 			subject3, _ := name.NewMatcher("*.prefix.example.*")

--- a/src/proxy/handler.go
+++ b/src/proxy/handler.go
@@ -74,7 +74,7 @@ func (handler *Handler) locate(request *http.Request) (*backend.Endpoint, error)
 		}
 	}
 
-	endpoint := handler.Locator.Locate(request.Context(), serverName)
+	endpoint, _ := handler.Locator.Locate(request.Context(), serverName)
 	if endpoint == nil {
 		return nil, statuspage.Error{
 			Inner:      errors.New("could not locate backend"),

--- a/src/static/env_test.go
+++ b/src/static/env_test.go
@@ -18,7 +18,7 @@ var _ = Describe("FromEnv", func() {
 				locator, err := fromEnv([]string{env})
 				Expect(err).ShouldNot(HaveOccurred())
 
-				endpoint := locator.Locate(context.Background(), name.Parse("foo.com"))
+				endpoint, _ := locator.Locate(context.Background(), name.Parse("foo.com"))
 				Expect(endpoint).To(Equal(expected))
 			},
 			Entry("TLS (https)", "ROUTE_FOO=foo.* https://foo.backend.com:1234", &backend.Endpoint{
@@ -78,16 +78,18 @@ var _ = Describe("FromEnv", func() {
 
 			Expect(err).ShouldNot(HaveOccurred())
 
-			endpoint := locator.Locate(
+			endpoint, score := locator.Locate(
 				context.Background(),
 				name.Parse("foo.com"),
 			)
+			Expect(score).To(BeNumerically(">", 0))
 			Expect(endpoint.Address).To(Equal("foo.backend.com:1234"))
 
-			endpoint = locator.Locate(
+			endpoint, score = locator.Locate(
 				context.Background(),
 				name.Parse("bar.com"),
 			)
+			Expect(score).To(BeNumerically(">", 0))
 			Expect(endpoint.Address).To(Equal("bar.backend.com:1234"))
 		})
 


### PR DESCRIPTION
Fixes #52 

I've taken the approach of allowing the `backend.Locator` implementations to return a score, so that they can still be searched hierarchically (ie, an "aggregate" locator that contains both the "static" locator and the "docker" locator).

This has the downside that every pattern needs to be searched on every request, so if @koden-km's initial tests with this branch go well for his use case I'll need to add some kind of server name -> endpoint cache, this is reasonably simple, but does need to be implemented separately in each locator as the rules for cache invalidation are wildly different.
