### PR TITLE
Add tls version configuration

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"crypto/tls"
 	"os"
 	"strconv"
 	"strings"
@@ -15,6 +16,9 @@ type Config struct {
 	Certificates       certificateConfig
 	ProxyProtocol      bool
 	CheckTimeout       time.Duration
+	MinTLSVersion      uint16
+	MaxTLSVersion      uint16
+	CipherSuite        []uint16
 }
 
 type certificateConfig struct {
@@ -45,6 +49,9 @@ func GetConfigFromEnvironment() *Config {
 		},
 		ProxyProtocol: envBool("PROXY_PROTOCOL", false),
 		CheckTimeout:  envDuration("CHECK_TIMEOUT", 500*time.Millisecond),
+		MinTLSVersion: envTLSVersion("TLS_MIN_VERSION"),
+		MaxTLSVersion: envTLSVersion("TLS_MAX_VERSION"),
+		CipherSuite:   envTLSCiphers("TLS_CIPHER_SUITE"),
 	}
 }
 
@@ -63,6 +70,46 @@ func envInt(key string, def int64) int64 {
 	}
 
 	return def
+}
+
+func envTLSVersion(key string) uint16 {
+	if value, ok := os.LookupEnv(key); ok {
+		switch strings.ToLower(value) {
+		case "tlsv1.0", "v1.0", "1.0", "1_0":
+			return tls.VersionTLS10
+		case "tlsv1.1", "v1.1", "1.1", "1_1":
+			return tls.VersionTLS11
+		case "tlsv1.2", "v1.2", "1.2", "1_2":
+			return tls.VersionTLS12
+		case "tlsv1.3", "v1.3", "1.3", "1_3":
+			return tls.VersionTLS13
+		default:
+			return 0
+		}
+	}
+
+	return 0
+}
+
+func envTLSCiphers(key string) []uint16 {
+	if value, ok := os.LookupEnv(key); ok {
+		o := []uint16{}
+		cipherStrings := strings.Split(value, ":")
+		cipherSuites := tls.CipherSuites()
+		for _, cipherString := range cipherStrings {
+			for _, cipherSuite := range cipherSuites {
+				if strings.EqualFold(cipherString, cipherSuite.Name) {
+					o = append(o, cipherSuite.ID)
+				}
+			}
+		}
+
+		if len(o) != 0 {
+			return o
+		}
+	}
+
+	return nil
 }
 
 func envBool(key string, def bool) bool {

--- a/cmd/honeycomb/main.go
+++ b/cmd/honeycomb/main.go
@@ -124,7 +124,7 @@ func main() {
 		},
 	}
 
-	prepareTLSConfig(tlsConfig)
+	prepareTLSConfig(config, tlsConfig)
 
 	server := http.Server{
 		Addr:      ":" + config.Port,
@@ -253,11 +253,13 @@ func secondaryCertificateProvider(
 	}, nil
 }
 
-func prepareTLSConfig(config *tls.Config) {
-	config.NextProtos = []string{"h2"}
-	config.MinVersion = tls.VersionTLS10
-	config.PreferServerCipherSuites = true
-	config.CurvePreferences = []tls.CurveID{tls.CurveP256, tls.CurveP384, tls.CurveP521}
+func prepareTLSConfig(config *cmd.Config, tlsConfig *tls.Config) {
+	tlsConfig.NextProtos = []string{"h2"}
+	tlsConfig.MinVersion = config.MinTLSVersion
+	tlsConfig.MaxVersion = config.MaxTLSVersion
+	tlsConfig.CipherSuites = config.CipherSuite
+	tlsConfig.PreferServerCipherSuites = true
+	tlsConfig.CurvePreferences = []tls.CurveID{tls.CurveP256, tls.CurveP384, tls.CurveP521}
 }
 
 func rootCAPool(


### PR DESCRIPTION
This PR adds support for defining minimum and maximum TLS versions and TLS cipher suites.

`TLS_MIN_VERSION`/`TLS_MAX_VERSION`: accepts a string like `v1.0` or `1.0`, if the option specified is invalid it is ignored.
`TLS_CIPHER_SUITE` accepts a colon-delimited list of ciphers similar to Apache, but using the names from the Golang TLS library (an example would be caddy or traefik)

Examples:
- `TLS_MIN_VERSION=1.0`
- `TLS_MAX_VERSION=1.1`
- `TLS_CIPHER_SUITE=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256:TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256`

Small changes related to development:
- Fixed minify, new versions don't just pass through unsupported types, it exits non-zero.
- added `docker-update` target, just to do a `docker service update` if `docker-services` has already been run.